### PR TITLE
Avoid duplicate counting

### DIFF
--- a/lib/ranges.js
+++ b/lib/ranges.js
@@ -47,7 +47,7 @@ exports.or = function(ranges1, ranges2) {
     var thisHigh = lookup[0].ranges[lookup[0].index + 1];
     var otherLow = lookup[1].ranges[lookup[1].index];
     var otherHigh = lookup[1].ranges[lookup[1].index + 1];
-    if (otherLow === undefined || thisHigh < otherLow + 1) {
+    if (otherLow === undefined || thisHigh < otherLow) {
       if (isNaN(low)) {
         ranges.push(thisLow, thisHigh);
       } else {

--- a/test/fixtures/canada-or-usa.js
+++ b/test/fixtures/canada-or-usa.js
@@ -2,7 +2,9 @@ const bitgeo = require('../../lib/index');
 const canada = require('../data/canada.json');
 const usa = require('../data/usa.json');
 
-module.exports = function() {
+exports = module.exports = function() {
   const options = {resolution: 0.25};
   return bitgeo(canada, options).or(bitgeo(usa, options));
 };
+
+exports.area = 11510.5;

--- a/test/fixtures/canada.js
+++ b/test/fixtures/canada.js
@@ -1,6 +1,8 @@
 const bitgeo = require('../../lib/index');
 const data = require('../data/canada.json');
 
-module.exports = function() {
+exports = module.exports = function() {
   return bitgeo(data, {resolution: 0.25});
 };
+
+exports.area = 6975.75;

--- a/test/fixtures/gallatin.js
+++ b/test/fixtures/gallatin.js
@@ -1,6 +1,8 @@
 const bitgeo = require('../../lib/index');
 const data = require('../data/gallatin.json');
 
-module.exports = function() {
+exports = module.exports = function() {
   return bitgeo(data, {resolution: 0.005});
 };
+
+exports.area = 158.24;

--- a/test/fixtures/mt.js
+++ b/test/fixtures/mt.js
@@ -1,6 +1,8 @@
 const bitgeo = require('../../lib/index');
 const data = require('../data/mt.json');
 
-module.exports = function() {
+exports = module.exports = function() {
   return bitgeo(data, {resolution: 0.025});
 };
+
+exports.area = 1810;

--- a/test/fixtures/usa.js
+++ b/test/fixtures/usa.js
@@ -1,6 +1,8 @@
 const bitgeo = require('../../lib/index');
 const data = require('../data/usa.json');
 
-module.exports = function() {
+exports = module.exports = function() {
   return bitgeo(data, {resolution: 0.25});
 };
+
+exports.area = 4569;

--- a/test/fixtures/world-and-usa.js
+++ b/test/fixtures/world-and-usa.js
@@ -2,7 +2,9 @@ const bitgeo = require('../../lib/index');
 const world = require('../data/world.json');
 const usa = require('../data/usa.json');
 
-module.exports = function() {
+exports = module.exports = function() {
   const options = {resolution: 0.25};
   return bitgeo(world, options).and(bitgeo(usa, options));
 };
+
+exports.area = 4569;

--- a/test/fixtures/world.js
+++ b/test/fixtures/world.js
@@ -1,6 +1,8 @@
 const bitgeo = require('../../lib/index');
 const data = require('../data/world.json');
 
-module.exports = function() {
+exports = module.exports = function() {
   return bitgeo(data, {resolution: 0.5});
 };
+
+exports.area = 40319;

--- a/test/fixtures/zigzag.js
+++ b/test/fixtures/zigzag.js
@@ -1,6 +1,6 @@
 const bitgeo = require('../../lib/index');
 
-module.exports = function() {
+exports = module.exports = function() {
   const ring = [];
   ring.push([0, 0]);
   for (let i = 20; i <= 90; i += 5) {
@@ -21,3 +21,5 @@ module.exports = function() {
     resolution: 0.25
   });
 };
+
+exports.area = 5888.25;

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -18,6 +18,8 @@ lab.experiment('integration', () => {
     lab.test(entry, done => {
       const factory = require(path.join(fixtures, entry));
       const bits = factory();
+      expect(bits.getArea()).to.be.about(factory.area, 1e-5);
+
       const width = bits.maxI + 1 - bits.minI;
       const height = bits.maxJ + 1 - bits.minJ;
 


### PR DESCRIPTION
Ranges were being generated like `[0, 10, 10, 20]`.  When calculating areas, this double counts the overlapping bit.