### PR TITLE
Support for non-zero origin

### DIFF
--- a/lib/bitbox.js
+++ b/lib/bitbox.js
@@ -7,6 +7,7 @@ function BitBox(config) {
   this.minJ = config.minJ;
   this.maxJ = config.maxJ;
   this.resolution = config.resolution;
+  this.origin = config.origin;
   this._ranges = config.ranges;
   this._area = NaN;
 }
@@ -48,6 +49,9 @@ BitBox.prototype.or = function(bits) {
   if (this.resolution !== bits.resolution) {
     throw new Error('BitBoxes must have the same resolution');
   }
+  if (this.origin[0] !== bits.origin[0] || this.origin[1] !== bits.origin[1]) {
+    throw new Error('BitBoxes must have the same origin');
+  }
   var ranges = {};
   for (var thisJ in this._ranges) {
     ranges[thisJ] = this._ranges[thisJ];
@@ -65,6 +69,7 @@ BitBox.prototype.or = function(bits) {
     minJ: Math.min(this.minJ, bits.minJ),
     maxJ: Math.max(this.maxJ, bits.maxJ),
     resolution: this.resolution,
+    origin: this.origin,
     ranges: ranges
   });
 };
@@ -72,6 +77,9 @@ BitBox.prototype.or = function(bits) {
 BitBox.prototype.and = function(bits) {
   if (this.resolution !== bits.resolution) {
     throw new Error('BitBoxes must have the same resolution');
+  }
+  if (this.origin[0] !== bits.origin[0] || this.origin[1] !== bits.origin[1]) {
+    throw new Error('BitBoxes must have the same origin');
   }
   var minI = Infinity;
   var maxI = -Infinity;
@@ -96,6 +104,7 @@ BitBox.prototype.and = function(bits) {
     minJ: minJ,
     maxJ: maxJ,
     resolution: this.resolution,
+    origin: this.origin,
     ranges: ranges
   });
 };

--- a/lib/linestring.js
+++ b/lib/linestring.js
@@ -6,8 +6,9 @@ var quantize = require('./segments').quantize;
 exports.getBits = function(coordinates, options) {
   options = options || {};
   var resolution = options.resolution || 1;
+  var origin = options.origin || [0, 0];
   var segments = prepare(coordinates);
-  var quantized = quantize(segments, resolution);
+  var quantized = quantize(segments, resolution, origin);
   var values = quantized.values;
 
   var ranges = {};
@@ -51,6 +52,7 @@ exports.getBits = function(coordinates, options) {
     maxI: quantized.maxI,
     minJ: quantized.minJ,
     maxJ: quantized.maxJ,
+    origin: origin,
     resolution: resolution
   });
 };

--- a/lib/point.js
+++ b/lib/point.js
@@ -3,8 +3,9 @@ var BitBox = require('./bitbox');
 exports.getBits = function(coordinates, options) {
   options = options || {};
   var resolution = options.resolution || 1;
-  var i = Math.floor(coordinates[0] / resolution);
-  var j = Math.floor(coordinates[1] / resolution);
+  var origin = options.origin || [0, 0];
+  var i = Math.floor((coordinates[0] - origin[0]) / resolution);
+  var j = Math.floor((coordinates[1] - origin[1]) / resolution);
   var ranges = {};
   ranges[j] = [i, i];
 
@@ -14,6 +15,7 @@ exports.getBits = function(coordinates, options) {
     maxI: i,
     minJ: j,
     maxJ: j,
+    origin: origin,
     resolution: resolution
   });
 };

--- a/lib/polygon.js
+++ b/lib/polygon.js
@@ -6,12 +6,13 @@ var quantize = require('./segments').quantize;
 exports.getBits = function(coordinates, options) {
   options = options || {};
   var resolution = options.resolution || 1;
+  var origin = options.origin || [0, 0];
   var segments;
   for (var i = 0, ii = coordinates.length; i < ii; ++i) {
     segments = prepare(coordinates[i], segments);
   }
 
-  var quantized = quantize(segments, resolution);
+  var quantized = quantize(segments, resolution, origin);
   var values = quantized.values;
   var ranges = {};
   var minJ = quantized.minJ;
@@ -41,6 +42,7 @@ exports.getBits = function(coordinates, options) {
     maxI: quantized.maxI,
     minJ: minJ,
     maxJ: maxJ,
-    resolution: resolution
+    resolution: resolution,
+    origin: origin
   });
 };

--- a/lib/segments.js
+++ b/lib/segments.js
@@ -12,7 +12,7 @@ var lower = exports.lower = function(test, comparison) {
       (test[0][1] === comparison[0][1] && test[1][1] < comparison[1][1]);
 };
 
-exports.quantize = function(segments, resolution) {
+exports.quantize = function(segments, resolution, origin) {
   var values = [];
   var minI = Infinity;
   var maxI = -Infinity;
@@ -22,10 +22,10 @@ exports.quantize = function(segments, resolution) {
     var segment = segments.segment;
     var lowPoint = segment[0];
     var highPoint = segment[1];
-    var lowI = Math.floor(lowPoint[0] / resolution);
-    var lowJ = Math.floor(lowPoint[1] / resolution);
-    var highI = Math.floor(highPoint[0] / resolution);
-    var highJ = Math.floor(highPoint[1] / resolution);
+    var lowI = Math.floor((lowPoint[0] - origin[0]) / resolution);
+    var lowJ = Math.floor((lowPoint[1] - origin[1]) / resolution);
+    var highI = Math.floor((highPoint[0] - origin[0]) / resolution);
+    var highJ = Math.floor((highPoint[1] - origin[1]) / resolution);
     // TODO: skip zero length segments
     if (lowI < minI) {
       minI = lowI;

--- a/test/lib/bitbox.test.js
+++ b/test/lib/bitbox.test.js
@@ -19,7 +19,7 @@ lab.experiment('constructor', () => {
 
 lab.experiment('#minI', () => {
 
-  lab.test('provides access to x0', done => {
+  lab.test('provides access to minI', done => {
     const bitbox = new BitBox({
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
@@ -34,7 +34,7 @@ lab.experiment('#minI', () => {
 
 lab.experiment('#maxI', () => {
 
-  lab.test('provides access to x0', done => {
+  lab.test('provides access to maxI', done => {
     const bitbox = new BitBox({
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
@@ -49,7 +49,7 @@ lab.experiment('#maxI', () => {
 
 lab.experiment('#minJ', () => {
 
-  lab.test('provides access to width', done => {
+  lab.test('provides access to minJ', done => {
     const bitbox = new BitBox({
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
@@ -57,6 +57,21 @@ lab.experiment('#minJ', () => {
       resolution: 1
     });
     expect(bitbox.minJ).to.equal(-10);
+    done();
+  });
+
+});
+
+lab.experiment('#maxJ', () => {
+
+  lab.test('provides access to maxJ', done => {
+    const bitbox = new BitBox({
+      minI: 0, maxI: 20,
+      minJ: -10, maxJ: 10,
+      ranges: {},
+      resolution: 1
+    });
+    expect(bitbox.maxJ).to.equal(10);
     done();
   });
 

--- a/test/lib/bitbox.test.js
+++ b/test/lib/bitbox.test.js
@@ -9,6 +9,7 @@ lab.experiment('constructor', () => {
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
       ranges: {},
+      origin: [0, 0],
       resolution: 1
     });
     expect(bitbox).to.be.an.instanceof(BitBox);
@@ -24,6 +25,7 @@ lab.experiment('#minI', () => {
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
       ranges: {},
+      origin: [0, 0],
       resolution: 1
     });
     expect(bitbox.minI).to.equal(0);
@@ -39,6 +41,7 @@ lab.experiment('#maxI', () => {
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
       ranges: {},
+      origin: [0, 0],
       resolution: 1
     });
     expect(bitbox.maxI).to.equal(20);
@@ -54,6 +57,7 @@ lab.experiment('#minJ', () => {
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
       ranges: {},
+      origin: [0, 0],
       resolution: 1
     });
     expect(bitbox.minJ).to.equal(-10);
@@ -69,6 +73,7 @@ lab.experiment('#maxJ', () => {
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
       ranges: {},
+      origin: [0, 0],
       resolution: 1
     });
     expect(bitbox.maxJ).to.equal(10);
@@ -87,6 +92,7 @@ lab.experiment('#getArea()', () => {
         1: [1, 1, 12, 20], // 10 bits
         3: [2, 10, 15, 15] // 10 bits
       },
+      origin: [0, 0],
       resolution: 10
     });
     expect(bitbox.getArea()).to.equal(2000);
@@ -103,6 +109,7 @@ lab.experiment('#maxJ', () => {
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
       ranges: {},
+      origin: [0, 0],
       resolution: 1
     });
     expect(bitbox.maxJ).to.equal(10);
@@ -118,6 +125,7 @@ lab.experiment('#resolution', () => {
       minI: 0, maxI: 20,
       minJ: -10, maxJ: 10,
       ranges: {},
+      origin: [0, 0],
       resolution: 5
     });
     expect(bitbox.resolution).to.equal(5);


### PR DESCRIPTION
By default, the origin is `0, 0`.

```js
i = (x - origin[0]) / resolution
j = (y - origin[1]) / resolution
```