### PR TITLE
Add contains method to bitbox

### DIFF
--- a/lib/bitbox.js
+++ b/lib/bitbox.js
@@ -133,4 +133,44 @@ BitBox.prototype.forEach = function(callback) {
   });
 };
 
-module.exports = BitBox;
+var portions = {
+  NONE: 0,
+  SOME: 1,
+  ALL: 2
+};
+
+BitBox.prototype.contains = function(minI, minJ, maxI, maxJ) {
+  var testRanges = [minI, maxI];
+  var portion = portions.NONE;
+  for (var j = minJ; j <= maxJ; ++j) {
+    var ranges = this._ranges[j];
+    if (!ranges) {
+      if (portion === portions.NONE) {
+        continue;
+      } else if (portion === portions.ALL) {
+        portion = portions.SOME;
+        break;
+      }
+    }
+    var contained = andRanges(ranges, testRanges);
+    if (contained.length === 0) {
+      if (portion === portions.NONE) {
+        continue;
+      } else if (portion === portions.ALL) {
+        portion = portions.SOME;
+        break;
+      }
+    } else {
+      if (contained[0] === minI && contained[1] === maxI) {
+        portion = portions.ALL;
+      } else {
+        portion = portions.SOME;
+        break;
+      }
+    }
+  }
+  return portion;
+};
+
+exports = module.exports = BitBox;
+exports.portions = portions;

--- a/lib/bitbox.js
+++ b/lib/bitbox.js
@@ -173,4 +173,6 @@ BitBox.prototype.contains = function(minI, minJ, maxI, maxJ) {
 };
 
 exports = module.exports = BitBox;
-exports.portions = portions;
+exports.NONE = portions.NONE;
+exports.SOME = portions.SOME;
+exports.ALL = portions.ALL;

--- a/test/lib/bitbox.test.js
+++ b/test/lib/bitbox.test.js
@@ -133,3 +133,55 @@ lab.experiment('#resolution', () => {
   });
 
 });
+
+lab.experiment('#contains()', () => {
+
+  lab.test('determines if none of the bits are true', done => {
+    const bitbox = new BitBox({
+      minI: 0, maxI: 10,
+      minJ: 0, maxJ: 2,
+      ranges: {
+        0: [0, 10],
+        1: [0, 10],
+        2: [0, 10]
+      },
+      origin: [0, 0],
+      resolution: 1
+    });
+    expect(bitbox.contains(20, 0, 30, 2)).to.equal(BitBox.portions.NONE);
+    done();
+  });
+
+  lab.test('determines if all of the bits are true', done => {
+    const bitbox = new BitBox({
+      minI: 0, maxI: 10,
+      minJ: 0, maxJ: 2,
+      ranges: {
+        0: [0, 10],
+        1: [0, 10],
+        2: [0, 10]
+      },
+      origin: [0, 0],
+      resolution: 1
+    });
+    expect(bitbox.contains(0, 0, 2, 2)).to.equal(BitBox.portions.ALL);
+    done();
+  });
+
+  lab.test('determines if some of the bits are true', done => {
+    const bitbox = new BitBox({
+      minI: 0, maxI: 10,
+      minJ: 0, maxJ: 2,
+      ranges: {
+        0: [0, 10],
+        1: [0, 10],
+        2: [0, 10]
+      },
+      origin: [0, 0],
+      resolution: 1
+    });
+    expect(bitbox.contains(5, 0, 20, 3)).to.equal(BitBox.portions.SOME);
+    done();
+  });
+
+});

--- a/test/lib/bitbox.test.js
+++ b/test/lib/bitbox.test.js
@@ -148,7 +148,7 @@ lab.experiment('#contains()', () => {
       origin: [0, 0],
       resolution: 1
     });
-    expect(bitbox.contains(20, 0, 30, 2)).to.equal(BitBox.portions.NONE);
+    expect(bitbox.contains(20, 0, 30, 2)).to.equal(BitBox.NONE);
     done();
   });
 
@@ -164,7 +164,7 @@ lab.experiment('#contains()', () => {
       origin: [0, 0],
       resolution: 1
     });
-    expect(bitbox.contains(0, 0, 2, 2)).to.equal(BitBox.portions.ALL);
+    expect(bitbox.contains(0, 0, 2, 2)).to.equal(BitBox.ALL);
     done();
   });
 
@@ -180,7 +180,7 @@ lab.experiment('#contains()', () => {
       origin: [0, 0],
       resolution: 1
     });
-    expect(bitbox.contains(5, 0, 20, 3)).to.equal(BitBox.portions.SOME);
+    expect(bitbox.contains(5, 0, 20, 3)).to.equal(BitBox.SOME);
     done();
   });
 


### PR DESCRIPTION
The `bitbox.contains()` method determines if bits in the provided range are all true, partially true, or all false.