### PR TITLE
Fix an edge case with contains

### DIFF
--- a/lib/bitbox.js
+++ b/lib/bitbox.js
@@ -162,7 +162,11 @@ BitBox.prototype.contains = function(minI, minJ, maxI, maxJ) {
       }
     } else {
       if (contained[0] === minI && contained[1] === maxI) {
-        portion = portions.ALL;
+        if (j === minJ || portion == portions.ALL) {
+          portion = portions.ALL;
+        } else {
+          portion = portions.SOME;
+        }
       } else {
         portion = portions.SOME;
         break;

--- a/test/lib/bitbox.test.js
+++ b/test/lib/bitbox.test.js
@@ -184,4 +184,20 @@ lab.experiment('#contains()', () => {
     done();
   });
 
+  lab.test('determines that some of the bits are true even if the bottom ones are all true', done => {
+    const bitbox = new BitBox({
+      minI: 0, maxI: 10,
+      minJ: 0, maxJ: 2,
+      ranges: {
+        0: [0, 10],
+        1: [0, 10],
+        2: [0, 10]
+      },
+      origin: [0, 0],
+      resolution: 1
+    });
+    expect(bitbox.contains(5, -1, 9, 2)).to.equal(BitBox.SOME);
+    done();
+  });
+
 });


### PR DESCRIPTION
Using `contains` if the last range is fully contained even though previous ranges aren't, the return value will be `ALL`.

This is a proposed fix. 